### PR TITLE
refactor: all styles for feature highlight, vertex highlight, copy/pa…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bingo_soft/mapmanager",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "description": "Map manager for GIS projects",
   "main": "src/MapManager.ts",
   "repository": {

--- a/src/Domain/Model/Feature/Feature.ts
+++ b/src/Domain/Model/Feature/Feature.ts
@@ -13,6 +13,8 @@ import LayerInterface from "../Layer/LayerInterface";
 import StyleFunction from "../Style/StyleFunctionType";
 import GeometryItem from "./GeometryItem";
 import VertexCoordinate from "./VertexCoordinate";
+import { HighlightFeatureStyle } from "../Style/HighlightFeatureStyle";
+import StyleBuilder from "../Style/StyleBuilder";
 
 /** Feature */
 export default class Feature { 
@@ -100,33 +102,9 @@ export default class Feature {
      * Highlights feature
      */
     public highlight(): void {
-        const selectStyleLinePolygon = new OlStyle({
-            stroke: new OlStroke({
-                color: "#555",
-                width: 3
-            }),
-            fill: new OlFill({
-                color: "rgba(128, 128, 128, 0.2)",
-            }) 
-        });
-        const selectStylePoint = new OlStyle({
-            image: new OlCircle({
-                radius: 3,
-                stroke: new OlStroke({
-                    color: "#555",
-                    width: 3
-                })
-            })
-        });
-        //debugger
-        //console.log(this.feature.getStyle());
         this.featureStyle = (<OlStyle> this.feature.getStyle());
-        const type = this.feature.getGeometry().getType();
-        if (type == "Point" || type == "MultiPoint") {
-            this.feature.setStyle(selectStylePoint);
-        } else {
-            this.feature.setStyle(selectStyleLinePolygon);
-        }
+        const styleFunc = new StyleBuilder(HighlightFeatureStyle).build(false);
+        this.setStyle(styleFunc);
     }
 
     /**

--- a/src/Domain/Model/Map/Map.ts
+++ b/src/Domain/Model/Map/Map.ts
@@ -45,6 +45,8 @@ import MeasureType from "../Interaction/MeasureType";
 import LayerBuilder from "../Layer/LayerBuilder";
 import VectorLayer from "../Layer/Impl/VectorLayer";
 import ObjectParser from "../../../Infrastructure/Util/ObjectParser";
+import StyleBuilder from "../Style/StyleBuilder";
+import { HighlightVertexStyle } from "../Style/HighlightVertexStyle";
 
 
 
@@ -678,20 +680,10 @@ export default class Map {
     public highlightVertex(coordinate: OlCoordinate.Coordinate, srsId: number): void {
         if (!this.vertexHighlightLayer) {
             this.vertexHighlightLayer = new OlVectorLayer({
-                source: new OlVectorSource(),
-                style: new OlStyle({
-                    image: new OlCircleStyle({
-                        radius: 3,
-                        fill: new OlFill({
-                            color: "magenta"
-                        }),
-                        stroke: new OlStroke({
-                            color: "magenta",
-                            width: 2
-                        }),
-                    }),
-                })
+                source: new OlVectorSource()
             });
+            const styleFunc = new StyleBuilder(HighlightVertexStyle).build(false);
+            this.vertexHighlightLayer.setStyle(styleFunc);
             this.vertexHighlightLayer.setMap(this.map);
         }
         const source = this.vertexHighlightLayer.getSource();

--- a/src/Domain/Model/Style/ClipboardStyle.ts
+++ b/src/Domain/Model/Style/ClipboardStyle.ts
@@ -1,7 +1,7 @@
 export const CopyStyle: unknown = {
     "point": {
-        "color": "#9AA894",
-        "opacity": 70
+        "marker_type": "simple_point",
+        "color": "#9AA894"
     },
     "linestring": {
         "color": "#9AA894",
@@ -16,8 +16,8 @@ export const CopyStyle: unknown = {
 
 export const CutStyle: unknown = {
     "point": {
-        "color": "#FF0000",
-        "opacity": 70
+        "marker_type": "simple_point",
+        "color": "#FF0000"
     },
     "linestring": {
         "color": "#FF0000",

--- a/src/Domain/Model/Style/HighlightFeatureStyle.ts
+++ b/src/Domain/Model/Style/HighlightFeatureStyle.ts
@@ -1,0 +1,17 @@
+export const HighlightFeatureStyle: unknown = {
+    "point": {
+        "marker_type": "simple_point",
+        "color": "#555",
+        "size": 3
+    },
+    "linestring": {
+        "color": "#555",
+        "stroke_width": 3
+    },
+    "polygon": {
+        "color": "#555",
+        "stroke_width": 3,
+        "background_color": "#808080",
+        "opacity": 20
+    }
+};

--- a/src/Domain/Model/Style/HighlightVertexStyle.ts
+++ b/src/Domain/Model/Style/HighlightVertexStyle.ts
@@ -1,0 +1,7 @@
+export const HighlightVertexStyle: unknown = {
+    "point": {
+        "marker_type": "simple_point",
+        "color": "magenta",
+        "size": 3
+    }
+};

--- a/src/Domain/Model/Style/StyleBuilder.ts
+++ b/src/Domain/Model/Style/StyleBuilder.ts
@@ -213,11 +213,12 @@ export default class StyleBuilder {
 
     /**
      * Builds style
+     * @param useExternalStyleBuilder - whether to use external style builder
      * @return style function
      */
-    public build(): StyleFunction {
+    public build(useExternalStyleBuilder = true): StyleFunction {
         return (feature: OlFeature, resolution: number): OlStyle | OlStyle[] => {
-            if (typeof this.externalStyleBuilder === "function") {
+            if (useExternalStyleBuilder && typeof this.externalStyleBuilder === "function") {
                 const featureProps = feature.getProperties();
                 const featureStyle = this.externalStyleBuilder(featureProps);
                 this.applyOptions(featureStyle);

--- a/src/MapManager.ts
+++ b/src/MapManager.ts
@@ -610,7 +610,7 @@ export default class MapManager {
      */
     public static setStyle(features: FeatureCollection, style: unknown): void {
         if (features && features.getLength()) {
-            const styleFunc = new StyleBuilder(style).build();
+            const styleFunc = new StyleBuilder(style).build(false);
             features.forEach((feature: Feature): void => {
                 feature.setStyle(styleFunc);
             });


### PR DESCRIPTION
…ste are now inside the separate files in Model/Style and in backend format. Real style construction is done via StyleBuilder instance